### PR TITLE
Generate images in same directory as source file

### DIFF
--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -68,6 +68,30 @@ Configure the plugin
 </project>
 ---
 
+* Output in same directory as source file
+
+  By setting the configuration option <<<outputInSourceDirectory>>> to true, 
+  the images will be generated in the same directory as the source file. This is useful for
+  using PlantUML diagrams in Javadoc, as described here: 
+  {{{http://plantuml.sourceforge.net/javadoc.html}http://plantuml.sourceforge.net/javadoc.html}}.
+  When this option is set to true, <<<outputDirectory>>> is ignored. Example configuration:
+  
+---
+<configuration>
+    <sourceFiles>
+        <directory>${basedir}</directory>
+        <includes>
+          <include>
+              src/main/java/**/*.java
+          </include>
+        </includes>
+    </sourceFiles>
+    <outputInSourceDirectory>
+    	true
+    </outputInSourceDirectory>
+</configuration>
+---
+
 Run goal
 
   Then execute command:


### PR DESCRIPTION
I have introduced a configuration option, `outputInSourceDirectory`. When this is set to true, the images will be generated in the same directory as the source file and `outputDirectory` is ignored. This is useful for using PlantUML diagrams in Javadoc, described here: http://plantuml.sourceforge.net/javadoc.html.
