### PR TITLE
Fixes #12

### DIFF
--- a/src/main/java/com/github/plantuml/maven/PlantUMLMojo.java
+++ b/src/main/java/com/github/plantuml/maven/PlantUMLMojo.java
@@ -35,6 +35,7 @@ import org.apache.maven.model.FileSet;
 import org.codehaus.plexus.util.FileUtils;
 
 /**
+ * @phase generate-resources
  * @goal generate
  */
 public class PlantUMLMojo extends AbstractMojo {


### PR DESCRIPTION
With this change I'm able to bind the plugin to a Maven phase:

```
<plugin>
    <groupId>com.github.jeluard</groupId>
    <artifactId>maven-plantuml-plugin</artifactId>
    <configuration>
        <sourceFiles>
            <directory>${basedir}</directory>
            <includes>
                <include>docs/**.plantuml</include>
            </includes>
        </sourceFiles>
        <outputInSourceDirectory>true</outputInSourceDirectory>
    </configuration>
    <executions>
        <execution>
            <goals>
                <goal>generate</goal>
            </goals>
        </execution>
    </executions>
</plugin>
```

It will automatically trigger the plugin execution during the "generate-resources" phase.

Ex:

```
mvn package
```

or

```
mvn install
```

or

```
mvn generate-resources
```
