### PR TITLE
Preserve directory structure

### DIFF
--- a/src/main/java/com/github/plantuml/maven/PlantUMLMojo.java
+++ b/src/main/java/com/github/plantuml/maven/PlantUMLMojo.java
@@ -180,6 +180,9 @@ public final class PlantUMLMojo extends AbstractMojo {
 
         if (this.outputInSourceDirectory) {
           this.option.setOutputDir(file.getParentFile());
+        } else {
+          this.option.setOutputDir(outputDirectory.toPath().resolve(
+              baseDir.toPath().relativize(file.toPath().getParent())).toFile());
         }
 
         final SourceFileReader sourceFileReader =


### PR DESCRIPTION
Instead of generating images directly on `outputDirectory`, use the same
directory structure as in `sourceFiles`.

Fixes #8
