### PR TITLE
reflect changes in PlantUML 8031

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A [maven](http://maven.apache.org/) plugin to generate UML diagrams using [PlantUML](http://plantuml.sourceforge.net/) syntax.
 
+# Important note
+
+If you want to use versions of PlantUML greater than 8031 you have to use version 1.2 of this plugin.
+
 # Usage
 
 To generate images from PlantUML description add following dependency to your pom.xml:

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>net.sourceforge.plantuml</groupId>
       <artifactId>plantuml</artifactId>
-      <version>7999</version>
+      <version>8031</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Changes done in the source files:

*README.MD:*
Added a line with important note on this plugin, reflecting runtime problems using older versions of this plugin together with newer versions of PlantUML (>=8031).

*pom.xml*
Dependency of PlantUML changed from 7999 to 8031. GeneratedImage is now an interface and no longer a class. If you use 1.1 of this plugin together with PlantUML 8033 runtime errors occur while executing Maven.