### PR TITLE
add "withMetadata" and "overwrite" flag

### DIFF
--- a/src/main/java/com/github/plantuml/maven/PlantUMLMojo.java
+++ b/src/main/java/com/github/plantuml/maven/PlantUMLMojo.java
@@ -24,6 +24,7 @@ import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.GeneratedImage;
 import net.sourceforge.plantuml.Option;
 import net.sourceforge.plantuml.OptionFlags;
+import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.SourceFileReader;
 import net.sourceforge.plantuml.preproc.Defines;
 
@@ -101,6 +102,20 @@ public final class PlantUMLMojo extends AbstractMojo {
    * @parameter property="plantuml.verbose" default-value="false"
    */
   private boolean verbose;
+  
+  /**
+   * Specify to include metadata in the output files.
+   * @parameter property="plantuml.withMetadata"
+   * @since 1.3
+   */
+  private boolean withMetadata = false;
+  
+  /**
+   * Specify to overwrite any output file, also if the target file is newer as the input file.
+   * @parameter property="plantuml.overwrite"
+   * @since 1.3
+   */
+  private boolean overwrite = false;
 
   protected final void setFormat(final String format) {
     if ("xmi".equalsIgnoreCase(format)) {
@@ -185,20 +200,31 @@ public final class PlantUMLMojo extends AbstractMojo {
         getCommaSeparatedList(this.sourceFiles.getExcludes())
       );
       for(final File file : files) {
-        getLog().info("Processing file <"+file+">");
-
+        File outDir;
         if (this.outputInSourceDirectory) {
-          this.option.setOutputDir(file.getParentFile());
+          outDir = file.getParentFile();
         } else {
-          this.option.setOutputDir(outputDirectory.toPath().resolve(
-              baseDir.toPath().relativize(file.toPath().getParent())).toFile());
+          outDir = outputDirectory.toPath().resolve(
+              baseDir.toPath().relativize(file.toPath().getParent())).toFile();
+        }
+        this.option.setOutputDir(outDir);
+        
+        FileFormatOption fileFormatOption = getFileFormatOption();
+        if (!overwrite){
+          String newName = fileFormatOption.getFileFormat().changeName(file.getName(), 0);
+          File targetFile = new File(outDir, newName);
+          if (targetFile.exists() && targetFile.lastModified() > file.lastModified()){
+            getLog().debug("Skip file <"+file+"> because target <"+targetFile+"> is newer");
+            continue;
+          }
         }
 
+        getLog().info("Processing file <"+file+">");
         final SourceFileReader sourceFileReader =
           new SourceFileReader(
             new Defines(), file, this.option.getOutputDir(),
             this.option.getConfig(), this.option.getCharset(),
-            this.option.getFileFormatOption());
+            fileFormatOption);
         for (final GeneratedImage image : sourceFileReader.getGeneratedImages()) {
           getLog().debug(image + " " + image.getDescription());
         }
@@ -219,6 +245,15 @@ public final class PlantUMLMojo extends AbstractMojo {
       }
     }
     return builder.toString();
+  }
+  
+  private FileFormatOption getFileFormatOption() {
+    FileFormatOption formatOptions = new FileFormatOption(this.option.getFileFormat(), this.withMetadata);
+    if (formatOptions.isWithMetadata() != withMetadata){
+      // Workarround to error in plantUML where the withMetadata flag is not correctly applied.
+      return new FileFormatOption(this.option.getFileFormat());
+    }
+    return formatOptions;
   }
 
 }


### PR DESCRIPTION
Hello,

I use your maven-plantuml-plugin to created *.png files from *.puml files directly in the source directory.
The *.png files are commited to the architecture documentation so that they can viewed in the git file browser.

During the process I observed that the *.png files are always modified with binary differences if created on different systems. This is because of the image metadata, which contain system environment information.

Another observed effect is that during re-execution of the goal any output file is overwritten without any change in the source *.puml file.

The provided changes contain solutions for both problems.
It would be nice if they can be integrated into your master.